### PR TITLE
Bugfix/fix models and paths with dashes

### DIFF
--- a/swagger-codegen-common/pom.xml
+++ b/swagger-codegen-common/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
@@ -223,4 +223,13 @@ public class JaxRsInterfaces extends JavaClientCodegen implements CodegenConfig,
 // modelTemplateFiles.put("model303.mustache", ".java");
     }
 
+    @Override
+    public String toApiName(String name) {
+        if (name.length() == 0) {
+            return "DefaultApi";
+        }
+
+        name = sanitizeName(name);
+        return camelize(name) + "Api";
+    }
 }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
@@ -221,4 +221,13 @@ public class AbstractSpringInterfaces extends JavaClientCodegen implements Codeg
     @Override
     public void enableBuilderSupport() { }
 
+    @Override
+    public String toApiName(String name) {
+        if (name.length() == 0) {
+            return "DefaultApi";
+        }
+
+        name = sanitizeName(name);
+        return camelize(name) + "Api";
+    }
 }


### PR DESCRIPTION
This bug is related to issues [#939](https://github.com/swagger-api/swagger-codegen/issues/939) and [#1142 of swagger-codegen](https://github.com/swagger-api/swagger-codegen/issues/1142):

When a dash (`-`) is used in a name of a model in the `definitions` sections or in the initial segment of a `path` name, the generated class has a `-` in the name, which cannot be compiled in Java.

This pull request uses the current SNAPSHOT version of swagger-codegen (where this is already fixed), as well as does a similar fix for the class names generated by the generators here.

Before merging this we should wait for a new release version of swagger-codegen and use that new version.