### PR TITLE
use baseName instead of paramName for the @RequestHeader annotations

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/bodyParams.mustache
@@ -1,1 +1,3 @@
-{{#isBodyParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/formParams.mustache
@@ -1,2 +1,8 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file")
+    InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
@@ -1,1 +1,3 @@
-{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/pathParams.mustache
@@ -1,1 +1,3 @@
-{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/queryParams.mustache
@@ -1,1 +1,3 @@
-{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
@@ -1,1 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/pathParams.mustache
@@ -1,1 +1,2 @@
-{{#isPathParam}} @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}} @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/queryParams.mustache
@@ -1,1 +1,2 @@
-{{#isQueryParam}} @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}} @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/bodyParams.mustache
@@ -1,1 +1,3 @@
-{{#isBodyParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
@@ -1,1 +1,3 @@
-{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/pathParams.mustache
@@ -1,1 +1,3 @@
-{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/queryParams.mustache
@@ -1,1 +1,3 @@
-{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/bodyParams.mustache
@@ -1,1 +1,2 @@
-{{#isBodyParam}} @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}} @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
@@ -1,1 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/pathParams.mustache
@@ -1,1 +1,2 @@
-{{#isPathParam}} @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}} @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/queryParams.mustache
@@ -1,1 +1,2 @@
-{{#isQueryParam}} @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}} @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}


### PR DESCRIPTION
This fixes the analogon to [Issue #1219 of swagger-codegen](https://github.com/swagger-api/swagger-codegen/issues/1219), i.e. that the names of parameters get sanitized, and then the original names can't be matched anymore.

In addition I added some line breaks and moved some spaces, so the annotations for a parameter are on lines before the parameter itself.

-----

Example (just the path + operation definition mit parameters, the responses and description are omitted):

```yaml
parameters:
  # global parameter definitions to be referenced in the operations.
  po_number_in_path:
    in: path
    name: po_number
    required: true
    type: string
    description: the purchase order number.

paths:
  /purchase-orders/{po_number}:
    parameters:
      - $ref: "#/parameters/po_number_in_path"
    put:
      summary: create or update a purchase order with known number.
      parameters:
        - name: purchase_order
          in: body
          schema:
            $ref: "#/definitions/purchase_order"
          required: true
        - name: If-None-Match
          in: header
          type: array
          collectionFormat: csv
          items:
            type: string
            format: quoted-entity-tag
          description: |
            Conditional request parameter, which indicates to execute an update
            only when the current value of the ETag doesn't match the parameter
            value.

            This is mainly used with the value `*` when it is expected that
            there currently is no PO with this number, i.e. when the client
            wants to restrict the action to creation, not update.

            You can also use a comma-separated list of entity-tags, then the
            request will only be executed when the current representation
            doesn't match any of those. (I don't yet see what usecase this would
            fulfill for our purchase order.)

            See also [RFC 7232](https://tools.ietf.org/html/rfc7232#section-3.2.)
```


Old generated code (just the method definition without the annotations before it, those don't change):
```java
  void purchaseOrdersPoNumberPut(@ApiParam(value = "" ,required=true ) @RequestBody PurchaseOrder purchaseOrder,
    @ApiParam(value = "the purchase order number.",required=true ) @PathVariable("poNumber") String poNumber,
    @ApiParam(value = "Conditional request parameter, which indicates to execute an update\nonly when the current value of the ETag doesn't match the parameter\nvalue.\n\nThis is mainly used with the value `*` when it is expected that\nthere currently is no PO with this number, i.e. when the client\nwants to restrict the action to creation, not update.\n\nYou can also use a comma-separated list of entity-tags, then the\nrequest will only be executed when the current representation\ndoesn't match any of those. (I don't yet see what usecase this would\nfulfill for our purchase order.)\n\nSee also [RFC 7232](https://tools.ietf.org/html/rfc7232#section-3.2.)"  ) @RequestHeader("ifNoneMatch") List<String> ifNoneMatch);
```
New generated code (ditto):
```java
  void purchaseOrdersPoNumberPut(@ApiParam(value = "", required=true)
    @RequestBody
    PurchaseOrder purchaseOrder,
    @ApiParam(value = "the purchase order number.", required=true )
    @PathVariable("po_number")
    String poNumber,
    @ApiParam(value = "Conditional request parameter, which indicates to execute an update\nonly when the current value of the ETag doesn't match the parameter\nvalue.\n\nThis is mainly used with the value `*` when it is expected that\nthere currently is no PO with this number, i.e. when the client\nwants to restrict the action to creation, not update.\n\nYou can also use a comma-separated list of entity-tags, then the\nrequest will only be executed when the current representation\ndoesn't match any of those. (I don't yet see what usecase this would\nfulfill for our purchase order.)\n\nSee also [RFC 7232](https://tools.ietf.org/html/rfc7232#section-3.2.)"  )
    @RequestHeader("If-None-Match")
    List<String> ifNoneMatch);
```

The important parts are the `If-None-Match` and `po_number` parameter names, the rest is just cosmetics.

I'm not sure if the `@ApiParam` annotations should also have the parameter names – I'll wait for comments on the issue at swagger-codegen.