### PR TITLE
Use the swagger name of the property

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/resources/JaxRsInterfaces/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/resources/JaxRsInterfaces/model.mustache
@@ -27,7 +27,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model.mustache
@@ -27,7 +27,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model303.mustache
@@ -29,7 +29,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model.mustache
@@ -24,7 +24,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model303.mustache
@@ -29,7 +29,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model.mustache
@@ -27,7 +27,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model303.mustache
@@ -29,7 +29,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model.mustache
@@ -24,7 +24,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model303.mustache
@@ -29,7 +29,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }


### PR DESCRIPTION
Use the swagger names of properties instead of the sanitized name fothe @JSonProperty annotations.

In swagger-codegen this has partly been fixed in [Pull Request #535](https://github.com/swagger-api/swagger-codegen/pull/535), and some more in [Pull Request #1239](https://github.com/swagger-api/swagger-codegen/pull/1239).