### PR TITLE
restore differences between languages

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
@@ -2,8 +2,6 @@ package {{package}};
 
 import {{modelPackage}}.*;
 
-import io.swagger.annotations.*;
-
 {{#imports}}import {{import}};
 {{/imports}}
 
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -23,16 +20,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 // GENERATED CLASS, DO NOT EDIT
 //
 
-@Api(value = "/{{baseName}}")
 {{#operations}}
 public interface {{classname}} {
 
 {{#operation}}
   @RequestMapping(value="/{{baseName}}{{path}}",method=RequestMethod.{{httpMethod}}{{#hasConsumes}},consumes={ {{#consumes}}"{{mediaType}}"{{#hasMore}},{{/hasMore}}{{/consumes}} }{{/hasConsumes}} {{#hasProduces}}, produces={ {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }{{/hasProduces}})
-  @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}"{{#returnBaseType}}, response = {{{returnBaseType}}}.class{{/returnBaseType}}{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}})
-  @ApiResponses(value = { {{#responses}}
-    @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},{{/hasMore}}{{/responses}}
-  })
   {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}});
 

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -33,7 +32,7 @@ public interface {{classname}} {
   @ApiResponses(value = { {{#responses}}
     @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},{{/hasMore}}{{/responses}}
   })
-  {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
+  {{#returnType}}ResponseEntity<{{{returnType}}}>{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}});
 
 {{/operation}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
@@ -2,8 +2,6 @@ package {{package}};
 
 import {{modelPackage}}.*;
 
-import io.swagger.annotations.*;
-
 {{#imports}}import {{import}};
 {{/imports}}
 
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -23,17 +20,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 // GENERATED CLASS, DO NOT EDIT
 //
 
-@Api(value = "/{{baseName}}")
 {{#operations}}
 public interface {{classname}} {
 
 {{#operation}}
   @RequestMapping(value="/{{baseName}}{{path}}",method=RequestMethod.{{httpMethod}}{{#hasConsumes}},consumes={ {{#consumes}}"{{mediaType}}"{{#hasMore}},{{/hasMore}}{{/consumes}} }{{/hasConsumes}} {{#hasProduces}}, produces={ {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }{{/hasProduces}})
-  @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}"{{#returnBaseType}}, response = {{{returnBaseType}}}.class{{/returnBaseType}}{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}})
-  @ApiResponses(value = { {{#responses}}
-    @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},{{/hasMore}}{{/responses}}
-  })
-  {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
+  {{#returnType}}ResponseEntity<{{{returnType}}}>{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}});
 
 {{/operation}}


### PR DESCRIPTION
Commit bf27245 tried to add an import for `RequestHeader`, but instead made the three api.mustache files identical to the one for "Springinterfaces". This rolls back the unintended part of that commit.