### PR TITLE
Bugfix/include required attribute in request header

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/bodyParams.mustache
@@ -1,1 +1,3 @@
-{{#isBodyParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/formParams.mustache
@@ -1,2 +1,8 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file")
+    InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
@@ -1,3 +1,3 @@
 {{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
-    @RequestHeader("{{baseName}}")
+    @RequestHeader({{#required}}"{{baseName}}"{{/required}}{{^required}}value="{{baseName}}", required=false{{/required}})
     {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/headerParams.mustache
@@ -1,1 +1,3 @@
-{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/pathParams.mustache
@@ -1,1 +1,3 @@
-{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/queryParams.mustache
@@ -1,1 +1,3 @@
-{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
@@ -1,1 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/headerParams.mustache
@@ -1,2 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+{{#isHeaderParam}} @RequestHeader({{#required}}"{{baseName}}"{{/required}}{{^required}}value="{{baseName}}", required=false{{/required}})
     {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/pathParams.mustache
@@ -1,1 +1,2 @@
-{{#isPathParam}} @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}} @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/queryParams.mustache
@@ -1,1 +1,2 @@
-{{#isQueryParam}} @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}} @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/bodyParams.mustache
@@ -1,1 +1,3 @@
-{{#isBodyParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
@@ -1,3 +1,3 @@
 {{#isHeaderParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
-    @RequestHeader("{{baseName}}")
+    @RequestHeader({{#required}}"{{baseName}}"{{/required}}{{^required}}value="{{baseName}}", required=false{{/required}})
     {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/headerParams.mustache
@@ -1,1 +1,3 @@
-{{#isHeaderParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/pathParams.mustache
@@ -1,1 +1,3 @@
-{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}} {{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/queryParams.mustache
@@ -1,1 +1,3 @@
-{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/bodyParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/bodyParams.mustache
@@ -1,1 +1,2 @@
-{{#isBodyParam}} @RequestBody {{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}} @RequestBody
+    {{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/formParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/formParams.mustache
@@ -1,2 +1,7 @@
-{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}} {{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}") @FormDataParam("file") InputStream inputStream,
-    @ApiParam(value = "file detail") @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, allowableValues="{{{allowableValues}}}"{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}})
+    @FormParam("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}@ApiParam(value = "{{{description}}}")
+    @FormDataParam("file") InputStream inputStream,
+    @ApiParam(value = "file detail")
+    @FormDataParam("file")
+    FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
@@ -1,1 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{paramName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}
+{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/headerParams.mustache
@@ -1,2 +1,2 @@
-{{#isHeaderParam}} @RequestHeader("{{baseName}}")
+{{#isHeaderParam}} @RequestHeader({{#required}}"{{baseName}}"{{/required}}{{^required}}value="{{baseName}}", required=false{{/required}})
     {{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/pathParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/pathParams.mustache
@@ -1,1 +1,2 @@
-{{#isPathParam}} @PathVariable("{{paramName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}} @PathVariable("{{baseName}}")
+    {{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/queryParams.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/queryParams.mustache
@@ -1,1 +1,2 @@
-{{#isQueryParam}} @RequestParam("{{paramName}}" {{#required}},required=true{{/required}}) {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}} @RequestParam("{{baseName}}"{{#required}}, required=true{{/required}})
+    {{{dataType}}} {{paramName}}{{/isQueryParam}}


### PR DESCRIPTION
 Include the required attribute in the @RequestHeader annotation.
    
The default value for this is `true`, so this needs to be included when the value is false.
Without that, the client gets a 400 error due to the missing header.

This pull request includes the changes from #14, so that one should be merged first.