### PR TITLE
Feature/use swagger codegen 2.1.6

### DIFF
--- a/swagger-codegen-common/pom.xml
+++ b/swagger-codegen-common/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-jaxrs-with-Builder/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-jaxrs-with-Builder/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-with-Builder-303/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-with-Builder-303/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-with-Builder/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-with-Builder/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-with-api-skipped/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-with-api-skipped/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-with-excluded-models/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-with-excluded-models/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml-with-model-skipped/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml-with-model-skipped/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-maven-plugin/src/it/kio-yaml/src/main/resources/kio-api.yaml
+++ b/swagger-codegen-maven-plugin/src/it/kio-yaml/src/main/resources/kio-api.yaml
@@ -129,8 +129,9 @@ paths:
           required: true
         - name: secret
           in: body
-          type: string
-          description: The application's new secret
+          schema:
+            type: string
+            description: The application's new secret
           required: true
       responses:
         200:
@@ -144,6 +145,7 @@ paths:
 
 definitions:
   Application:
+    type: object
     properties:
       id:
         type: string
@@ -168,6 +170,7 @@ definitions:
         description: URL of documentation
 
   ApplicationDetails:
+    type: object
     properties:
       name:
         type: string
@@ -195,6 +198,7 @@ definitions:
       - scm_url
 
   ApplicationSummary:
+    type: object
     properties:
       id:
         type: string
@@ -207,6 +211,7 @@ definitions:
         description: ID of the team, responsible for this application
 
   Error:
+    type: object
     properties:
       code:
         type: integer

--- a/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
@@ -59,7 +59,7 @@ public class JaxRsInterfaces extends JavaClientCodegen implements CodegenConfig,
 
     public JaxRsInterfaces() {
         super();
-        templateDir = "JaxRsInterfaces";
+        embeddedTemplateDir = templateDir = "JaxRsInterfaces";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
@@ -58,7 +58,7 @@ public class AbstractSpringInterfaces extends JavaClientCodegen implements Codeg
 
     public AbstractSpringInterfaces() {
         super();
-        templateDir = "SpringInterfaces";
+        embeddedTemplateDir = templateDir = "SpringInterfaces";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfaces.java
@@ -34,7 +34,7 @@ public class SpringInterfaces extends AbstractSpringInterfaces {
 
     public SpringInterfaces() {
         super();
-        templateDir = "SpringInterfaces";
+        embeddedTemplateDir = templateDir = "SpringInterfaces";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesNoSwaggerAnnotations.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesNoSwaggerAnnotations.java
@@ -34,7 +34,7 @@ public class SpringInterfacesNoSwaggerAnnotations extends AbstractSpringInterfac
 
     public SpringInterfacesNoSwaggerAnnotations() {
         super();
-        templateDir = "SpringInterfacesNoSwaggerAnnotations";
+        embeddedTemplateDir = templateDir = "SpringInterfacesNoSwaggerAnnotations";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesNoSwaggerAnnotations.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesNoSwaggerAnnotations.java
@@ -15,6 +15,11 @@
  */
 package de.zalando.stups.swagger.codegen.language;
 
+import java.util.Map;
+
+import io.swagger.codegen.CodegenModel;
+import io.swagger.models.Model;
+
 /**
  * https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/JaxRSServerCodegen.java.
  *
@@ -24,10 +29,12 @@ public class SpringInterfacesNoSwaggerAnnotations extends AbstractSpringInterfac
 
     protected String sourceFolder = "";
 
+    @Override
     public String getName() {
         return "springinterfacesNoSwaggerAnnotations";
     }
 
+    @Override
     public String getHelp() {
         return "Generates Spring-Interfaces without Swagger-Annotations.";
     }
@@ -37,6 +44,15 @@ public class SpringInterfacesNoSwaggerAnnotations extends AbstractSpringInterfac
         embeddedTemplateDir = templateDir = "SpringInterfacesNoSwaggerAnnotations";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
+    }
+
+    @Override
+    public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
+        final CodegenModel cgModel = super.fromModel(name, model, allDefinitions);
+        // these are imports for the swagger annotations. We don't want those.
+        cgModel.imports.remove("ApiModel");
+        cgModel.imports.remove("ApiModelProperty");
+        return cgModel;
     }
 
     @Override

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntity.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntity.java
@@ -41,7 +41,7 @@ public class SpringInterfacesResponseEntity extends AbstractSpringInterfaces {
 
     public SpringInterfacesResponseEntity() {
         super();
-        templateDir = "SpringInterfacesResponseEntity";
+        embeddedTemplateDir = templateDir = "SpringInterfacesResponseEntity";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntityNoSwaggerAnnotations.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntityNoSwaggerAnnotations.java
@@ -43,7 +43,7 @@ public class SpringInterfacesResponseEntityNoSwaggerAnnotations extends Abstract
 
     public SpringInterfacesResponseEntityNoSwaggerAnnotations() {
         super();
-        templateDir = "SpringInterfacesResponseEntityNoSwaggerAnnotations";
+        embeddedTemplateDir = templateDir = "SpringInterfacesResponseEntityNoSwaggerAnnotations";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
     }

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntityNoSwaggerAnnotations.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/SpringInterfacesResponseEntityNoSwaggerAnnotations.java
@@ -15,6 +15,11 @@
  */
 package de.zalando.stups.swagger.codegen.language;
 
+import java.util.Map;
+
+import io.swagger.codegen.CodegenModel;
+import io.swagger.models.Model;
+
 /**
  * https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-
  * codegen/src/main/java/com/wordnik/swagger/codegen/languages/
@@ -46,6 +51,15 @@ public class SpringInterfacesResponseEntityNoSwaggerAnnotations extends Abstract
         embeddedTemplateDir = templateDir = "SpringInterfacesResponseEntityNoSwaggerAnnotations";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
+    }
+
+    @Override
+    public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
+        final CodegenModel cgModel = super.fromModel(name, model, allDefinitions);
+        // these are imports for the swagger annotations. We don't want those.
+        cgModel.imports.remove("ApiModel");
+        cgModel.imports.remove("ApiModelProperty");
+        return cgModel;
     }
 
     @Override

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model.mustache
@@ -2,9 +2,6 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/model303.mustache
@@ -4,7 +4,6 @@ package {{package}};
 {{/imports}}
 
 import javax.validation.constraints.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model.mustache
@@ -2,8 +2,6 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/model303.mustache
@@ -4,7 +4,6 @@ package {{package}};
 {{/imports}}
 
 import javax.validation.constraints.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model.mustache
@@ -2,9 +2,6 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/model303.mustache
@@ -4,7 +4,6 @@ package {{package}};
 {{/imports}}
 
 import javax.validation.constraints.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model.mustache
@@ -2,8 +2,6 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model303.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/model303.mustache
@@ -4,7 +4,6 @@ package {{package}};
 {{/imports}}
 
 import javax.validation.constraints.*;
-import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
 {{#model}}{{#description}}


### PR DESCRIPTION
This bumps the swagger-codegen version to the current 2.1.6. My goal is to use one of the new features in that version (see #28 for that, to be merged after this one).

I had to do two changes due to changes in swagger-codegen (see commit comments).
There might be other ones necessary which my tests didn't catch.

*Update:* A third change was necessary, fixing the kio-api.yaml for the integration tests.

Maybe we could think about integrating the language-libraries into the main project, so they automatically get updated when the structure changes?