### PR TITLE
Don't produce content type when controller method return type is void.

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
@@ -184,6 +184,7 @@ public class AbstractSpringInterfaces extends JavaClientCodegen implements Codeg
 
                 if (operation.returnType == null) {
                     operation.returnType = getVoidReturnType();
+                    operation.hasProduces = Boolean.FALSE;
                 } else if (operation.returnType.startsWith("List")) {
                     String rt = operation.returnType;
                     int end = rt.lastIndexOf(">");


### PR DESCRIPTION
This shouldn't hurt anything, but it's more correct not to use "produces" annotation field for void return types. Also improves readability slightly.