### PR TITLE
fix for issue #37 - BasePath not generated

### DIFF
--- a/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/JaxRsInterfaces.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.models.Swagger;
 import org.zalando.stups.swagger.codegen.ConfigurableCodegenConfig;
 
 import io.swagger.codegen.CodegenConfig;
@@ -49,6 +50,12 @@ public class JaxRsInterfaces extends JavaClientCodegen implements CodegenConfig,
 
     public String getName() {
         return "jaxrsinterfaces";
+    }
+
+    @Override
+    public void preprocessSwagger(Swagger swagger) {
+        vendorExtensions.put("basePath", swagger.getBasePath());
+        super.preprocessSwagger(swagger);
     }
 
     public String getHelp() {

--- a/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/resources/JaxRsInterfaces/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-jaxrs-interfaces/src/main/resources/JaxRsInterfaces/api.mustache
@@ -19,7 +19,7 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
-@Path("/{{baseName}}")
+@Path("{{vendorExtensions.basePath}}/{{baseName}}")
 @io.swagger.annotations.Api(value = "/{{baseName}}", description = "the {{baseName}} API")
 {{#operations}}
 public interface {{classname}} {

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/java/de/zalando/stups/swagger/codegen/language/AbstractSpringInterfaces.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.models.Swagger;
 import org.zalando.stups.swagger.codegen.ConfigurableCodegenConfig;
 
 import com.google.common.collect.Lists;
@@ -65,6 +66,12 @@ public class AbstractSpringInterfaces extends JavaClientCodegen implements Codeg
     @Override
     public String getName() {
         return "springinterfaces";
+    }
+
+    @Override
+    public void preprocessSwagger(Swagger swagger) {
+        vendorExtensions.put("basePath", swagger.getBasePath());
+        super.preprocessSwagger(swagger);
     }
 
     @Override

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfaces/api.mustache
@@ -25,8 +25,9 @@ import org.springframework.web.bind.annotation.RequestPart;
 // GENERATED CLASS, DO NOT EDIT
 //
 
-@Api(value = "/{{baseName}}")
+@Api(value = "{{vendorExtensions.basePath}}/{{baseName}}")
 {{#operations}}
+@RequestMapping(value="{{vendorExtensions.basePath}}")
 public interface {{classname}} {
 
 {{#operation}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesNoSwaggerAnnotations/api.mustache
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 //
 
 {{#operations}}
+@RequestMapping(value="{{vendorExtensions.basePath}}")
 public interface {{classname}} {
-
 {{#operation}}
   @RequestMapping(value="/{{baseName}}{{path}}",method=RequestMethod.{{httpMethod}}{{#vendorExtensions.consumesExpected}}{{#hasConsumes}},consumes={ {{#consumes}}"{{mediaType}}"{{#hasMore}},{{/hasMore}}{{/consumes}} }{{/hasConsumes}}{{/vendorExtensions.consumesExpected}} {{#hasProduces}}, produces={ {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }{{/hasProduces}})
   {{>returnTypes}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntity/api.mustache
@@ -26,8 +26,9 @@ import org.springframework.web.bind.annotation.RequestPart;
 // GENERATED CLASS, DO NOT EDIT
 //
 
-@Api(value = "/{{baseName}}")
+@Api(value = "{{vendorExtensions.basePath}}/{{baseName}}")
 {{#operations}}
+@RequestMapping(value="{{vendorExtensions.basePath}}")
 public interface {{classname}} {
 
 {{#operation}}

--- a/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
+++ b/swagger-codegen-templates/swagger-codegen-template-spring-interfaces/src/main/resources/SpringInterfacesResponseEntityNoSwaggerAnnotations/api.mustache
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 //
 
 {{#operations}}
+@RequestMapping(value="{{vendorExtensions.basePath}}")
 public interface {{classname}} {
 
 {{#operation}}


### PR DESCRIPTION
I fixed https://github.com/zalando-stups/swagger-codegen-tooling/issues/37. The basePath is taken from the Swagger definition and generated as jax-rs / spring annotation on class level.